### PR TITLE
Implement the module to create `AWS EC2 Container Registry`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 # Module directory
 .terraform/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.tfstate.backup
 
 # Module directory
-.terraform/
-.idea/
+.terraform
+.idea
+*.iml

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2017 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
 # tf_ecr
-The module creates a Docker Container registry using AWS ECR
+This module creates an AWS ECR Docker Container registry.
+
 
 ## Usage
 
-Note: You should setting the IAM role names for registry access as a module variable `roles`.
+The module works in two distinct modes:
+
+1. If you provide the existing IAM Role names in the `roles` attribute, the Roles will be granted permissions to work with the created registry.
+
+2. If the `roles` attribute is omitted or is an empty list, a new IAM Role will be created and granted all the required permissions to work with the registry.
+The Role name will be assigned to the output variable `role_name`.
+In addition, an `EC2 Instance Profile` will be created from the new IAM Role, which might be assigned to EC2 instances granting them permissions to work with the ECR registry.
+
 
 Include this repository as a module in your existing terraform code:
 ```
+# IAM Role is provided. It will be granted ECR permissions
 data "aws_iam_role" "ecr" {
   name = "ecr"
 }
@@ -20,8 +29,6 @@ module "ecr" {
 }
 ```
 
-This will create a `registry`
-
 
 ## Variables
 
@@ -29,13 +36,14 @@ This will create a `registry`
 |:----------------------------:|:--------------:|:--------------------------------------------------------------------------------------------------------:|:-------:|
 | `namespace`                  | `global`       | Namespace (e.g. `cp` or `cloudposse`) - required for `tf_label` module                                   | Yes     |
 | `stage`                      | `default`      | Stage (e.g. `prod`, `dev`, `staging` - required for `tf_label` module                                    | Yes     |
-| `name`                       | `admin`        | Name  (e.g. `bastion` or `db`) - required for `tf_label` module                                          | Yes     |
-| `roles`                      | []             | List of IAM role names of principals allowed to use the container registry (users, groups, Roles)              | Yes     |
+| `name`                       | `admin`        | The Name of the application or solution  (e.g. `bastion` or `portal`) - required for `tf_label` module                                          | Yes     |
+| `roles`                      | []             | List of IAM role names that will be granted permissions to use the container registry              | No (optional)     |
+
 
 ## Outputs
 
 | Name                | Decription                                                                              |
 |:-------------------:|:---------------------------------------------------------------------------------------:|
-| `registry_id`       | ID of the new AWS Container Registry                                                    |
-| `registry_url`      | URL to the new AWS Container Registry                                                   |
-| `role_name`         | The name of IAM role that has access to the registry                                    |
+| `registry_id`       | ID of the created AWS Container Registry                                                    |
+| `registry_url`      | URL to the created AWS Container Registry                                                   |
+| `role_name`         | (Optional) The name of the newly created IAM role that has access to the registry                                    |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # tf_ecr
 The module creates a Docker Container registry using AWS ECR
+
+## Usage
+
+Note: You should setting the IAM role names for registry access as a module variable `roles`.
+
+Include this repository as a module in your existing terraform code:
+```
+data "aws_iam_role" "ecr" {
+  name = "ecr"
+}
+
+module "ecr" {
+  source              = "git::https://github.com/cloudposse/tf_ecr.git?ref=tags/0.1.0"
+  name                = "${var.name}"
+  namespace           = "${var.namespace}"
+  stage               = "${var.stage}"
+  roles               = ["${data.aws_iam_role.ecr.name}"]
+}
+```
+
+This will create a `registry`
+
+
+## Variables
+
+|  Name                        |  Default       |  Description                                                                                             | Required|
+|:----------------------------:|:--------------:|:--------------------------------------------------------------------------------------------------------:|:-------:|
+| `namespace`                  | `global`       | Namespace (e.g. `cp` or `cloudposse`) - required for `tf_label` module                                   | Yes     |
+| `stage`                      | `default`      | Stage (e.g. `prod`, `dev`, `staging` - required for `tf_label` module                                    | Yes     |
+| `name`                       | `admin`        | Name  (e.g. `bastion` or `db`) - required for `tf_label` module                                          | Yes     |
+| `roles`                      | []             | List of IAM role names of principals allowed to use the container registry (users, groups, Roles)              | Yes     |
+
+## Outputs
+
+| Name                | Decription                                                                              |
+|:-------------------:|:---------------------------------------------------------------------------------------:|
+| `registry_id`       | ID of the new AWS Container Registry                                                    |
+| `registry_url`      | URL to the new AWS Container Registry                                                   |
+| `role_name`         | The name of IAM role that has access to the registry                                    |

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,75 @@
+data "aws_iam_policy_document" "ecr" {
+  statement {
+    sid    = "node"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "${var.node_arns}",
+      ]
+    }
+
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+      "ecr:DescribeImages",
+      "ecr:DeleteRepository",
+    ]
+  }
+
+  statement {
+    sid    = "user"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "${var.user_arns}",
+      ]
+    }
+
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:DescribeRepositories",
+      "ecr:GetRepositoryPolicy",
+      "ecr:ListImages",
+      "ecr:DescribeImages",
+      "ecr:DeleteRepository",
+      "ecr:BatchDeleteImage",
+      "ecr:SetRepositoryPolicy",
+      "ecr:DeleteRepositoryPolicy",
+    ]
+  }
+}
+
+module "label" {
+  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.1.0"
+  namespace = "${var.namespace}"
+  stage     = "${var.stage}"
+  name      = "${var.name}"
+}
+
+resource "aws_ecr_repository" "default" {
+  name = "${module.label.id}"
+}
+
+resource "aws_ecr_repository_policy" "policy" {
+  repository = "${aws_ecr_repository.default.name}"
+  policy     = "${data.aws_iam_policy_document.ecr.json}"
+}

--- a/main.tf
+++ b/main.tf
@@ -89,10 +89,13 @@ data "aws_iam_policy_document" "resource" {
 }
 
 module "label" {
-  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.2.0"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.name}"
+  source     = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.2.0"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
 }
 
 resource "aws_ecr_repository" "default" {

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "default_ecr" {
 }
 
 data "aws_iam_policy_document" "resource" {
-  count = "${signum(length(var.roles)) == 1 ? 1 : 0}"
+  count = "${signum(length(var.roles))}"
 
   statement {
     sid    = "ecr"
@@ -103,7 +103,7 @@ resource "aws_ecr_repository" "default" {
 }
 
 resource "aws_ecr_repository_policy" "default" {
-  count      = "${signum(length(var.roles)) == 1 ? 1 : 0}"
+  count      = "${signum(length(var.roles))}"
   repository = "${aws_ecr_repository.default.name}"
   policy     = "${data.aws_iam_policy_document.resource.json}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 data "aws_iam_role" "default" {
-  count     = "${signum(length(var.roles)) == 1 ? length(var.roles) : 0}"
-  role_name = "${element(var.roles, count.index)}"
+  count = "${signum(length(var.roles)) == 1 ? length(var.roles) : 0}"
+  name  = "${element(var.roles, count.index)}"
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -116,7 +116,7 @@ resource "aws_ecr_repository_policy" "default_ecr" {
 
 resource "aws_iam_policy" "default" {
   name        = "${module.label.id}"
-  description = "Allow IAM Users have to access to call ecr:GetAuthorizationToken"
+  description = "Allow IAM Users to call ecr:GetAuthorizationToken"
   policy      = "${data.aws_iam_policy_document.token.json}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ data "aws_iam_policy_document" "resource" {
 }
 
 module "label" {
-  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.1.0"
+  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.2.0"
   namespace = "${var.namespace}"
   stage     = "${var.stage}"
   name      = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 data "aws_iam_role" "default" {
-  count = "${signum(length(var.roles)) == 1 ? length(var.roles) : 0}"
-  name  = "${element(var.roles, count.index)}"
+  count     = "${signum(length(var.roles)) == 1 ? length(var.roles) : 0}"
+  role_name = "${element(var.roles, count.index)}"
 }
 
 data "aws_iam_policy_document" "assume_role" {

--- a/output.tf
+++ b/output.tf
@@ -1,21 +1,9 @@
-output "arn" {
-  value = "${aws_ecr_repository.default.arn}"
-}
-
-output "name" {
-  value = "${aws_ecr_repository.default.name}"
-}
-
 output "registry_id" {
   value = "${aws_ecr_repository.default.registry_id}"
 }
 
-output "repository_url" {
+output "registry_url" {
   value = "${aws_ecr_repository.default.repository_url}"
-}
-
-output "role_arn" {
-  value = "${aws_iam_role.default.arn}"
 }
 
 output "role_name" {

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,19 @@
+output "arn" {
+  value = "${aws_ecr_repository.default.arn}"
+}
+
+output "name" {
+  value = "${aws_ecr_repository.default.name}"
+}
+
+output "registry_id" {
+  value = "${aws_ecr_repository.default.registry_id}"
+}
+
+output "repository_url" {
+  value = "${aws_ecr_repository.default.repository_url}"
+}
+
+output "policy.registry_id" {
+  value = "${aws_ecr_repository_policy.policy.registry_id}"
+}

--- a/output.tf
+++ b/output.tf
@@ -2,10 +2,11 @@ output "arn" {
   value = "${aws_ecr_repository.default.arn}"
 }
 
-output "name" {
-  value = "${aws_ecr_repository.default.name}"
-}
-
+//
+//output "name" {
+//  value = "${aws_ecr_repository.default.name}"
+//}
+//
 output "registry_id" {
   value = "${aws_ecr_repository.default.registry_id}"
 }
@@ -14,6 +15,10 @@ output "repository_url" {
   value = "${aws_ecr_repository.default.repository_url}"
 }
 
-output "policy.registry_id" {
-  value = "${aws_ecr_repository_policy.policy.registry_id}"
+output "role_arn" {
+  value = "${aws_iam_role.role.arn}"
+}
+
+output "role_name" {
+  value = "${aws_iam_role.role.name}"
 }

--- a/output.tf
+++ b/output.tf
@@ -2,11 +2,10 @@ output "arn" {
   value = "${aws_ecr_repository.default.arn}"
 }
 
-//
-//output "name" {
-//  value = "${aws_ecr_repository.default.name}"
-//}
-//
+output "name" {
+  value = "${aws_ecr_repository.default.name}"
+}
+
 output "registry_id" {
   value = "${aws_ecr_repository.default.registry_id}"
 }
@@ -16,9 +15,9 @@ output "repository_url" {
 }
 
 output "role_arn" {
-  value = "${aws_iam_role.role.arn}"
+  value = "${aws_iam_role.default.arn}"
 }
 
 output "role_name" {
-  value = "${aws_iam_role.role.name}"
+  value = "${aws_iam_role.default.name}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,18 +1,12 @@
-variable "name" {
-  description = "Name of the repository"
-  default     = ""
-}
+variable "name" {}
 
-variable "namespace" {
-  default = ""
-}
+variable "namespace" {}
 
-variable "stage" {
-  default = ""
-}
+variable "stage" {}
 
-variable "principals" {
+variable "roles" {
   type        = "list"
-  description = "Principal ARNs to provide with access to the ECR"
+  description = "Principal IAM roles to provide with access to the ECR"
   default     = []
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -9,3 +9,18 @@ variable "roles" {
   description = "Principal IAM roles to provide with access to the ECR"
   default     = []
 }
+
+variable "delimiter" {
+  type    = "string"
+  default = "-"
+}
+
+variable "attributes" {
+  type    = "list"
+  default = []
+}
+
+variable "tags" {
+  type    = "map"
+  default = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -11,15 +11,8 @@ variable "stage" {
   default = ""
 }
 
-variable "node_arns" {
-  type = "list"
-  description = "Principal ARN of EC2 node to provide with access to the ECR"
+variable "principals" {
+  type        = "list"
+  description = "Principal ARNs to provide with access to the ECR"
   default     = []
 }
-
-variable "user_arns" {
-  type = "list"
-  description = "Principal ARN of users to provide with access to the ECR"
-  default     = []
-}
-

--- a/variables.tf
+++ b/variables.tf
@@ -9,4 +9,3 @@ variable "roles" {
   description = "Principal IAM roles to provide with access to the ECR"
   default     = []
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,25 @@
+variable "name" {
+  description = "Name of the repository"
+  default     = ""
+}
+
+variable "namespace" {
+  default = ""
+}
+
+variable "stage" {
+  default = ""
+}
+
+variable "node_arns" {
+  type = "list"
+  description = "Principal ARN of EC2 node to provide with access to the ECR"
+  default     = []
+}
+
+variable "user_arns" {
+  type = "list"
+  description = "Principal ARN of users to provide with access to the ECR"
+  default     = []
+}
+


### PR DESCRIPTION
## What
* Implement the TF module to create `AWS EC2 Container Registry`

## Why
* We need this in order to store our images for Docker containers

## Reference
* Based on https://bitbucket.org/cultivatedops/terraform-module-aws-ecr
* Docker usage https://aws.amazon.com/blogs/compute/authenticating-amazon-ecr-repositories-for-docker-cli-with-credential-helper/