### PR TITLE
Add `repository_name` output variable

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -6,6 +6,10 @@ output "registry_url" {
   value = "${aws_ecr_repository.default.repository_url}"
 }
 
+output "repository_name" {
+  value = "${aws_ecr_repository.default.name}"
+}
+
 output "role_name" {
   value = "${aws_iam_role.default.name}"
 }


### PR DESCRIPTION
## What

* Add `repository_name` output variable


## Why

* The `name` of the created ECR repository is used in other Terraform modules to push Docker images to ECR
